### PR TITLE
Point to new 'open-nti-input-jti' container which contains 0.4.1 vers…

### DIFF
--- a/plugins/input-jti/Dockerfile
+++ b/plugins/input-jti/Dockerfile
@@ -1,7 +1,7 @@
 FROM fluent/fluentd:v0.12.29
 MAINTAINER Damien Garros <dgarros@gmail.com>
 
-ENV FLUENTD_JUNIPER_VERSION 0.4.0
+ENV FLUENTD_JUNIPER_VERSION 0.4.1
 
 USER root
 WORKDIR /home/fluent


### PR DESCRIPTION
…ion of fluent-parser-juniper-telemetry gem